### PR TITLE
First code to select homes from get_home_data

### DIFF
--- a/custom_components/vaillant_vsmart/manifest.json
+++ b/custom_components/vaillant_vsmart/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/OToussaint/home-assistant-vaillant-vsmart-reloaded/issues",
   "requirements": [
-    "vaillant-netatmo-api==0.12.3"
+    "vaillant-netatmo-api-reloaded==0.12.3"
   ],
   "version": "0.11.2"
 }


### PR DESCRIPTION
Modified code to select correct homes from get_home_data.
In case of single homes record, always use that one.
Better would be to have home_id and room_id added during async_setup_entry.

Requires latest version of vaillant_netatmo_api including PR 'Additional information returned by get_home_data'