### PR TITLE
Fixed Config problems

### DIFF
--- a/custom_components/vaillant_vsmart/__init__.py
+++ b/custom_components/vaillant_vsmart/__init__.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_TOKEN
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.typing import ConfigType
 from vaillant_netatmo_api import ThermostatClient, Token, TokenStore
 
 from .const import (
@@ -24,7 +25,7 @@ from .websockets import async_register_websockets
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up Vaillant vSMART component."""
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/vaillant_vsmart/manifest.json
+++ b/custom_components/vaillant_vsmart/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/OToussaint/home-assistant-vaillant-vsmart-reloaded/issues",
   "requirements": [
-    "vaillant-netatmo-api-reloaded==0.12.3"
+    "vaillant-netatmo-api-reloaded==0.12.5"
   ],
-  "version": "0.11.2"
+  "version": "0.11.3"
 }


### PR DESCRIPTION
Fix :
ImportError: cannot import name 'Config' from 'homeassistant.core'

Background:
The integration fails to load on Home Assistant 2026.1.0 with an ImportError. Home Assistant 2026.1 removed the deprecated Config class from homeassistant.core. It was due to be removed in 2025.11 but It seems it wan't until 2026.1.

Made the changes as documented in https://github.com/MislavMandaric/home-assistant-vaillant-vsmart/issues/429

Updated also some versions numbers in manifest.