### PR TITLE
Pass sw_version to device registry as a string

### DIFF
--- a/custom_components/vaillant_vsmart/entity.py
+++ b/custom_components/vaillant_vsmart/entity.py
@@ -29,6 +29,12 @@ UPDATE_INTERVAL = timedelta(minutes=5)
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
+def _format_sw_version(firmware: Any) -> str | None:
+    """Return the firmware version as a string, as required by the device registry."""
+
+    return None if firmware is None else str(firmware)
+
+
 class VaillantData:
     """Class holding data which coordinator provides to the entity."""
 
@@ -137,7 +143,7 @@ class VaillantDeviceEntity(CoordinatorEntity[VaillantData]):
         return {
             "identifiers": {(DOMAIN, self._device.id)},
             "name": self._device.station_name,
-            "sw_version": self._device.firmware,
+            "sw_version": _format_sw_version(self._device.firmware),
             "manufacturer": self._device.type,
         }
 
@@ -195,7 +201,7 @@ class VaillantModuleEntity(CoordinatorEntity[VaillantData]):
         return {
             "identifiers": {(DOMAIN, self._module.id)},
             "name": self._module.module_name,
-            "sw_version": self._module.firmware,
+            "sw_version": _format_sw_version(self._module.firmware),
             "manufacturer": self._device.type,
             "via_device": (DOMAIN, self._device.id),
         }
@@ -262,7 +268,7 @@ class VaillantProgramEntity(CoordinatorEntity[VaillantData]):
         return {
             "identifiers": {(DOMAIN, self._module.id)},
             "name": self._module.module_name,
-            "sw_version": self._module.firmware,
+            "sw_version": _format_sw_version(self._module.firmware),
             "manufacturer": self._device.type,
             "via_device": (DOMAIN, self._device.id),
         }
@@ -329,7 +335,7 @@ class VaillantMeasurementEntity(CoordinatorEntity[VaillantData]):
         return {
             "identifiers": {(DOMAIN, self._module.id)},
             "name": self._module.module_name,
-            "sw_version": self._module.firmware,
+            "sw_version": _format_sw_version(self._module.firmware),
             "manufacturer": self._device.type,
             "via_device": (DOMAIN, self._device.id),
         }


### PR DESCRIPTION
The Vaillant API returns firmware versions as integers, which Home Assistant deprecates and will reject in 2026.12.0. Convert the value to a string (preserving None) in all four device_info properties.